### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,17 @@
   }
 ]
 ```
+Refresh mode
 
+This plugins supports these refresh modes:
 
+NONE (autoRefreshEnabled and keepAlive both set to false) - no auto refresh, we will connect to roomba and poll status when requested by home app. Please note that this will cause "Updating" status for all homebridge accessories.
+
+AUTO REFRESH (autoRefreshEnabled set to true) - we will connect to roomba, every pollingInterval seconds, and store the status in cache. if pollingInterval = cacheTTL - 10 (or more), this will make sure we will always have a valid status.
+
+KEEP ALIVE (keepAlive set to true) - we will keep a connection to roomba, this will cause app to fail to connect to roomba in local network mode (cloud mode will work just fine, even in your home wifi). This will lead to better performance (status will refresh faster, and toggle will work faster as well). Keep in mind this will increase the Roomba battery consumption.
+
+Source: https://github.com/stvmallen/homebridge-roomba-stv#refresh-mode
 
 
 ### Credits:


### PR DESCRIPTION
It appears the 'refresh mode' of homebridge-roomba2 is the the same as homebridge-roomba-stv but there's no documentation on this. Suggest adding for those new to the plugin.