### PR TITLE
New Option to Stop on Off

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -57,7 +57,8 @@
             },
             "dockOnStop": {
             "type": "boolean",
-            "title": "If true, does not go home when stopped.",
+            "title": "Do not send home when stopped",
+            "default": false,
             "required": true
             },
             "cacheTTL": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -55,6 +55,11 @@
             "title": "Show if bin is full as a contact sensor",
             "required": false
             },
+            "dockWhenStopped": {
+            "type": "boolean",
+            "title": "If true, Send home when stopped.",
+            "required": true
+            },
             "cacheTTL": {
                 "type": "number",
                 "title": "TTL Cache",

--- a/config.schema.json
+++ b/config.schema.json
@@ -57,7 +57,7 @@
             },
             "dockOnStop": {
             "type": "boolean",
-            "title": "If true, Send home when stopped.",
+            "title": "If true, does not go home when stopped.",
             "required": true
             },
             "cacheTTL": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -55,7 +55,7 @@
             "title": "Show if bin is full as a contact sensor",
             "required": false
             },
-            "dockWhenStopped": {
+            "dockOnStop": {
             "type": "boolean",
             "title": "If true, Send home when stopped.",
             "required": true

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const roombaAccessory = function (log, config) {
     this.showDockAsContactSensor = config.dockContactSensor == undefined ? true : config.dockContactSensor;
     this.showRunningAsContactSensor = config.runningContactSensor;
     this.showBinStatusAsContactSensor = config.binContactSensor;
+    this.dockOnStop = config.dockOnStop;
     this.cacheTTL = config.cacheTTL || 5;
     this.roomba = null;
 
@@ -103,6 +104,7 @@ roombaAccessory.prototype = {
                 }
             });
         } else {
+            if (!this.dockOnStop) {
             this.log("Roomba pause and dock");
 
             this.onConnected(roomba, async () => {
@@ -124,6 +126,16 @@ roombaAccessory.prototype = {
                     callback(error);
                 }
             });
+        }
+        else {
+        this.log("Roomba Pausing");
+        
+        await roomba.pause();
+        
+        this.log("Roomba paused");
+        
+        }
+        
         }
     },
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const roombaAccessory = function (log, config) {
     this.showDockAsContactSensor = config.dockContactSensor == undefined ? true : config.dockContactSensor;
     this.showRunningAsContactSensor = config.runningContactSensor;
     this.showBinStatusAsContactSensor = config.binContactSensor;
-    this.dockOnStop = config.dockOnStop;
+    this.nodockOnStop = config.dockOnStop;
     this.cacheTTL = config.cacheTTL || 5;
     this.roomba = null;
 
@@ -104,7 +104,7 @@ roombaAccessory.prototype = {
                 }
             });
 } else {
-            if (!this.dockOnStop) {
+            if (!this.nodockOnStop) {
             this.log("Roomba pause and dock");
 
             this.onConnected(roomba, async () => {
@@ -133,11 +133,13 @@ roombaAccessory.prototype = {
                 try {
                     this.log("Roomba job is ending");
 
-                    await roomba.pause();
+                    await roomba.stop();
 
                     callback();
 
+                    this.endRoombaIfNeeded(roomba);
                     this.log("Roomba Stopped");
+                    
         } catch (error) {
                     this.log("Roomba failed: %s", error.message);
 

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ roombaAccessory.prototype = {
                     this.endRoombaIfNeeded(roomba);
                 }
             });
-        } else {
+} else {
             if (!this.dockOnStop) {
             this.log("Roomba pause and dock");
 
@@ -127,17 +127,28 @@ roombaAccessory.prototype = {
                 }
             });
         }
-        else {
+               else {
         this.log("Roomba Pausing");
-        
-        await roomba.pause();
-        
-        this.log("Roomba paused");
-        
-        }
-        
-        }
-    },
+        this.onConnected(roomba, async () => {
+                try {
+                    this.log("Roomba job is ending");
+
+                    await roomba.pause();
+
+                    callback();
+
+                    this.log("Roomba Stopped");
+        } catch (error) {
+                    this.log("Roomba failed: %s", error.message);
+
+                    this.endRoombaIfNeeded(roomba);
+
+                    callback(error);
+                }
+        });
+    }}
+},
+
 
     endRoombaIfNeeded(roomba) {
         if (!this.keepAliveEnabled) {


### PR DESCRIPTION
Changes to two files in this PR:

1. config.schema.json
2. index.js

Today's Behavior
-----
Today when you turn off the device in homekit the plugin pauses the job and sends the robot home. For some users this behavior is not ideal. Perhaps they are stopping it to make things quiet for a minute, and the command to dock turns it back on.

Changes in PR
----
This PR gives a new config option "Do not send home on stop." 
- 1. The default value is set as false, which will allow the plugin to operate at status quo. 
- 2. If set to true, when the device is turned off in HomeKit, the Roomba job will stop and then end. The 'end' seems necessary to keep the robot from immediately turning back on at the next poll.

N.B.: The reason I chose the command 'stop' instead of 'pause' is because I could not find a way to properly implement a 'resume' command. We would need to identify that the robot is in a paused state and choose to send a 'resume' command instead of 'clean,' when turned back on, as sending clean command on a paused job results in an error. This way we are ending the job, which is not ideal, but allows the controls in HomeKit to be more consistently.

Let me know if you have any questions on this.