### PR TITLE
Add debug option to schema layout

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -81,6 +81,7 @@
         { "type": "section", "title": "Roomba Details", "items": [ "name", "model", "serialnum", "blid", "robotpwd", "ipaddress" ] },
         { "type": "section", "title": "Contact Sensors", "items": [ "dockContactSensor", "dockingContactSensor", "runningContactSensor", "binContactSensor" ] },
         { "type": "section", "title": "Switches", "items": [ "homeSwitch" ] },
-        { "type": "section", "title": "Behaviour", "items": [ "stopBehaviour" ] }
+        { "type": "section", "title": "Behaviour", "items": [ "stopBehaviour" ] },
+        { "type": "section", "title": "Plugin Options", "items": [ "debug" ] }
     ]
 }


### PR DESCRIPTION
Currently the new debug option does not appear in the UI, even though present in the schema, because it is not included in the layout section.

This change adds "debug" to the schema layout so that the option actually appears in the Homebridge Plugin UI.

![Screen Shot 2022-03-16 at 11 04 50 AM](https://user-images.githubusercontent.com/8211291/158621595-afd487de-606f-42a6-bc4d-a948558261cc.jpg)
.